### PR TITLE
iOS 13.2(17B80)

### DIFF
--- a/13.2(17B80)/DeveloperDiskImage.dmg.signature
+++ b/13.2(17B80)/DeveloperDiskImage.dmg.signature
@@ -1,0 +1,1 @@
+"Æ‹Ì‰ÆeŽ7CDÃ“çðíHò(ÂŽ“TfËMœ‹ÒDÌÂ†æò7ÏuéòÈb=Œ‡Oùä²ë€ßGÕñš(òxÈ˜ù˜n\éŒK‹ë¢±,LôAµyE‡./Ñá@¹P÷]’|3¥=5O{¡%«5µ×aù®]8‚©NcE


### PR DESCRIPTION
> iOS 13.2 (17B80) device support files iOS 13.2 - distributed with Xcode Version 11.2 (11B52)
> https://developer.apple.com/documentation/xcode_release_notes/xcode_11_2_release_notes