### PR TITLE
iOS 13.5 update

### DIFF
--- a/13.5 (17F61)/DeveloperDiskImage.dmg.signature
+++ b/13.5 (17F61)/DeveloperDiskImage.dmg.signature
@@ -1,0 +1,2 @@
+/D#E7.~d½ÖñžçÃqTÑêY»„ÛK
+Ñ"7Ïåè¬túõö:±¿·p]¥kPFËjá*ÃÀéSHÔU´Œ%ZÒ[¡¿ÐþèÖðq8ša9õ4+®|N9¼W°¾jrPïÍçq¶NkR?ƒœÓßtrË^É†q.


### PR DESCRIPTION
> iOS 13.5 (17F61) device support files iOS 13.5 beta - distributed with Xcode Version 11.5 beta (11E608c)
> https://developer.apple.com/documentation/xcode_release_notes/xcode_11_5_beta_release_notes/