### PR TITLE
iOS 13.6 device support files - iOS 13.6

### DIFF
--- a/13.6 (17G61)/DeveloperDiskImage.dmg.signature
+++ b/13.6 (17G61)/DeveloperDiskImage.dmg.signature
@@ -1,0 +1,1 @@
+ŽM‡W¥M_†ˆ=™ÂmÕ:Ò»0òé@$†Ñ„¼ªëÜhvcÌŠúN"µYüp3øH©G¸¶2½É:–N˜<A9,ÈVõ¡LÎ0´†S„)¼#S°—7mÀÛ,J=÷©DvlpºHé6õ`IôÀK;@Ö×5;[


### PR DESCRIPTION
> iOS 13.6 (17G61) device support files iOS 13.6 - distributed with Xcode Version 12 beta 3 (12A8169g)
> https://developer.apple.com/documentation/xcode_release_notes/xcode_12_beta_release_notes/