### PR TITLE
iOS 14.0 device support files - iOS 14.0 beta

### DIFF
--- a/14.0 (18A5332e)/DeveloperDiskImage.dmg.signature
+++ b/14.0 (18A5332e)/DeveloperDiskImage.dmg.signature
@@ -1,0 +1,1 @@
+xVG+¹†q¹qü¸¸¤œîÚÔi×Õ®–ïAjQD;”#€™ÙÞJ A	¢FÄçÒúde\âSl¤’“¡džpv! Šìÿ±U§Ý7´6ˆ‹±‘7Ê_››MÑnþázÚÓTª¦iãÅ“Ç1šxÔDÓ\R


### PR DESCRIPTION
> iOS 14.0 (18A5332e) device support files iOS 14.0 beta - distributed with Xcode Version 12.0 beta 3 (12A8169g)
> https://developer.apple.com/documentation/xcode_release_notes/xcode_12_beta_release_notes/